### PR TITLE
EAS-2776 Remove hard-coded credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Ensure docker is installed/running
+
     brew install qemu
     https://www.docker.com/products/docker-desktop/
 
 # Clone this repository
+
     git clone git@github.com:alphagov/emergency-alerts-localenv.git
     cd emergency-alerts-localenv
 
 # Clone all Emergency Alerts repos (not all are listed here)
+
     cd repos
     git clone git@github.com:alphagov/emergency-alerts-api.git
     git clone git@github.com:alphagov/emergency-alerts-govuk.git
@@ -15,24 +18,47 @@
     git clone git@github.com:alphagov/emergency-alerts-admin.git
 
 # Download broadcast-areas.sqlite3 from S3
-You can use the emergency-alerts-development account.  You can find it in the bucket prefixed with `eas-app-postcode-bucket-`.
+
+You can use the emergency-alerts-development account. You can find it in the bucket prefixed with `eas-app-postcode-bucket-`.
 After you have downloaded the file, place it in the `emergency-alerts-localenv/repos/emergency-alerts-admin/app/broadcast_areas/` directory.
-    
+
+# Set Postgres Credentials
+
+    Modify the `emergency-alerts-localenv/environment.sh` file by adding the credentials for the environment variables
+      MASTER_USERNAME
+      MASTER_PASSWORD
+      SECRET_KEY
+      DANGEROUS_SALT
+      ENCRYPTION_DANGEROUS_SALT
+      ENCRYPTION_SECRET_KEY
+      ADMIN_CLIENT_SECRET
+      POSTGRES_PASSWORD
+      POSTGRES_USER
+      POSTGRES_DB
+    using the values outlined in this guidance note:
+        https://gds-ea.atlassian.net/wiki/spaces/EA/pages/192217089/Setting+up+Local+Development+Environment#Getting-API-setup
+
 # Bring up the containers
+
     cd emergency-alerts-api
     docker compose up api -d
     docker compose up db-init
 
 # Once this completes and returns to a prompt
+
     docker compose down db-init
     docker compose up admin -d
 
 # Check that the admin site works
+
     docker compose up admin
+
 Once this completes and shows waiting for connections, open a local browser and visit http://localhost:6012
 
 # Bring up the govuk container
+
     docker compose up govuk
 
 # Check that the govuk site works
+
 Once this completes and shows waiting for connections, open a local browser and visit http://localhost:6017/alerts

--- a/compose.yml
+++ b/compose.yml
@@ -60,9 +60,9 @@ services:
     container_name: postgres
     restart: always
     environment:
-      POSTGRES_PASSWORD: root
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: $POSTGRES_PASSWORD
+      POSTGRES_USER: $POSTGRES_USER
+      POSTGRES_DB: $POSTGRES_DB
       USER: $USER
     volumes:
       - ./postgres:/docker-entrypoint-initdb.d:ro

--- a/environment.sh
+++ b/environment.sh
@@ -12,13 +12,18 @@ export RDS_HOST='host.docker.internal'
 export RDS_PORT=5432
 export RDS_USER='eas-user'
 export RDS_REGION='eu-west-2'
-export MASTER_USERNAME='eas-user'
-export MASTER_PASSWORD='password'
+
+export MASTER_USERNAME=
+export MASTER_PASSWORD=
 export API_HOST_NAME=http://host.docker.internal:6011
 export ADMIN_EXTERNAL_URL=http://host.docker.internal:6012
 
-export SECRET_KEY='dev-notify-secret-key'
-export DANGEROUS_SALT='dev-notify-salt'
-export ENCRYPTION_DANGEROUS_SALT='dev-notify-salt'
-export ENCRYPTION_SECRET_KEY='dev-notify-secret-key'
-export ADMIN_CLIENT_SECRET='dev-notify-secret-key'
+export SECRET_KEY=
+export DANGEROUS_SALT=
+export ENCRYPTION_DANGEROUS_SALT=
+export ENCRYPTION_SECRET_KEY=
+export ADMIN_CLIENT_SECRET=
+
+export POSTGRES_PASSWORD=
+export POSTGRES_USER=
+export POSTGRES_DB=


### PR DESCRIPTION
Hard-coded credentials have been removed from the compose.yml file.

These credentials are only used when running docker containers locally, so guidance has been provided so that the checked-in environment.sh file can be set up with the correct credentials - see the general 'api' setup page: https://gds-ea.atlassian.net/wiki/spaces/EA/pages/192217089/Setting+up+Local+Development+Environment#Getting-API-setup