### PR TITLE
chore: Update README with Zscaler MitM VPN info

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ git clone https://github.com/alphagov/emergency-alerts-admin.git
 
 Running on Linux? Make sure the repos have rw for everyone - as the containers run as non-root and will need access to bind mounts of their respective repo folders.
 
-**If you're using a VPN which does MitM traffic inspection**: You will need to install the root CA certificate on your base image. The quickest way to do this is to go to Keychain Access, search for the VPN CA (e.g., "Zscaler"), right-click, and export the CA certificate as a `.pem` file. Then place that under the root of your `emergency-alerts-utils` repository, named `vpn-ca.pem`. It'll be picked up by the Docker build, and in turn inherited by the application images.
+**If you're using a VPN which does MitM traffic inspection**: You will need to install the root CA certificate on your base image. The quickest way to do this is to go to Keychain Access (on macOS), search for the VPN CA (e.g., "Zscaler"), right-click, and export the CA certificate as a `.pem` file. Then place that under the root of your `emergency-alerts-utils` repository, named `vpn-ca.pem`. It'll be picked up by the Docker build, and in turn inherited by the application images.
 
 > You'll want to have suitable virtual environments for each Python project and run a `make bootstrap` within them. But if you're just after running containers locally immediately you can sidestep this a bit:
 > ```bash

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ git clone https://github.com/alphagov/emergency-alerts-admin.git
 
 Running on Linux? Make sure the repos have rw for everyone - as the containers run as non-root and will need access to bind mounts of their respective repo folders.
 
-**If you're using a new technologist device**: The Zscaler VPN does MitM traffic inspection, which means you will need to install the root CA certificate on your base image. The quickest way to do this is to go to Keychain Access, search for "Zscaler", right-click, and export the "Zscaler Root CA" as a `.pem` file. Then place that under the root of your `emergency-alerts-utils` repository, named `vpn-ca.pem`. It'll be picked up by the Docker build, and in turn inherited by the application images.
+**If you're using a VPN which does MitM traffic inspection**: You will need to install the root CA certificate on your base image. The quickest way to do this is to go to Keychain Access, search for the VPN CA (e.g., "Zscaler"), right-click, and export the CA certificate as a `.pem` file. Then place that under the root of your `emergency-alerts-utils` repository, named `vpn-ca.pem`. It'll be picked up by the Docker build, and in turn inherited by the application images.
 
 > You'll want to have suitable virtual environments for each Python project and run a `make bootstrap` within them. But if you're just after running containers locally immediately you can sidestep this a bit:
 > ```bash

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ git clone https://github.com/alphagov/emergency-alerts-admin.git
 
 Running on Linux? Make sure the repos have rw for everyone - as the containers run as non-root and will need access to bind mounts of their respective repo folders.
 
+**If you're using a new technologist device**: The Zscaler VPN does MitM traffic inspection, which means you will need to install the root CA certificate on your base image. The quickest way to do this is to go to Keychain Access, search for "Zscaler", right-click, and export the "Zscaler Root CA" as a `.pem` file. Then place that under the root of your `emergency-alerts-utils` repository, named `vpn-ca.pem`. It'll be picked up by the Docker build, and in turn inherited by the application images.
+
 > You'll want to have suitable virtual environments for each Python project and run a `make bootstrap` within them. But if you're just after running containers locally immediately you can sidestep this a bit:
 > ```bash
 > # in repos/


### PR DESCRIPTION
This PR gives instructions as to how to configure the base image (and by extension, each of the application images) to use a CA cert for cases where a VPN is used that intercepts traffic for inspection (MitM). This is required for functionality on new technologist laptops.