### PR TITLE
EAS-2972: Localenv: Rearchitect away from Celery to separate API and Periodiq containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Modify the `emergency-alerts-localenv/environment.sh` file by adding the credent
  - ENCRYPTION_DANGEROUS_SALT
  - ENCRYPTION_SECRET_KEY
  - ADMIN_CLIENT_SECRET
+ - GOVUK_CLIENT_SECRET
  - POSTGRES_PASSWORD
  - POSTGRES_USER
 
@@ -78,7 +79,7 @@ Now you should be able to ask Docker Compose to come up. We use a shared based i
 You may also need to ensure Postgres and Localstack are up and running before the others - Celery nopes out immediately if SQS isn't populated.
 ```
 . ./environment.sh
-docker compose up -d utils localstack pg jaeger lambda
+docker compose up --build -d utils localstack pg jaeger lambda
 docker compose build api
 docker compose up -d
 ```

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Modify the `emergency-alerts-localenv/environment.sh` file by adding the credent
  - ENCRYPTION_SECRET_KEY
  - ADMIN_CLIENT_SECRET
  - GOVUK_CLIENT_SECRET
+ - GOVUK_ALERTS_PUBLISH_CLIENT_SECRET
  - POSTGRES_PASSWORD
  - POSTGRES_USER
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Modify the `emergency-alerts-localenv/environment.sh` file by adding the credent
 In general you can largely make these values up, but you'll only want to set these once for a given DB's lifetime.
 
 Now you should be able to ask Docker Compose to come up. We use a shared based image which there isn't great native support for.
-You may also need to ensure Postgres and Localstack are up and running before the others - Celery nopes out immediately if SQS isn't populated.
+You may also need to ensure Postgres and Localstack are up and running before the others.
 ```
 . ./environment.sh
 docker compose up --build -d utils localstack pg jaeger lambda

--- a/compose.yml
+++ b/compose.yml
@@ -193,9 +193,6 @@ services:
     user: root # Override so we can install packages
     restart: "no"
     entrypoint: /eas/db-init.sh
-    environment:
-      POSTGRES_USER: $POSTGRES_USER
-      POSTGRES_PASSWORD: $POSTGRES_PASSWORD
     volumes:
       - ${LOCAL_WORKSPACE_FOLDER:-.}/repos/emergency-alerts-api:/eas/emergency-alerts-api:z
       - ${LOCAL_WORKSPACE_FOLDER:-.}/repos/emergency-alerts-utils:/eas/emergency-alerts-utils:z
@@ -251,4 +248,3 @@ services:
 
 volumes:
   pg-data: {}
-  minio-data: {}

--- a/compose.yml
+++ b/compose.yml
@@ -22,13 +22,6 @@ services:
       - . /eas/emergency-alerts-api/environment.sh && bash /start-api.sh
     environment:
       SERVICE_ACTION: run_api
-
-      AWS_ACCESS_KEY_ID: aws_key
-      AWS_SECRET_ACCESS_KEY: aws_secret
-      AWS_DEFAULT_REGION: us-east-1
-      AWS_ENDPOINT_URL_CLOUDWATCH: http://localstack:4566
-      AWS_ENDPOINT_URL_SQS: http://localstack:4566
-      SQS_QUEUE_BASE_URL: http://sqs.us-east-1.localstack:4566/000000000000
       AWS_ENDPOINT_URL_LAMBDA: http://lambda:5000
 
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://jaeger:4318/v1/traces
@@ -63,13 +56,6 @@ services:
       SERVICE_ACTION: run_worker
       WORKER_QUEUE_NAMES: local-dramatiq-periodic-tasks local-dramatiq-broadcast-tasks local-dramatiq-high-priority-tasks
 
-      AWS_ACCESS_KEY_ID: aws_key
-      AWS_SECRET_ACCESS_KEY: aws_secret
-      AWS_DEFAULT_REGION: us-east-1
-      AWS_ENDPOINT_URL_CLOUDWATCH: http://localstack:4566
-      AWS_ENDPOINT_URL_SQS: http://localstack:4566
-      SQS_QUEUE_BASE_URL: http://sqs.us-east-1.localstack:4566/000000000000
-
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://jaeger:4318/v1/traces
       OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
       OTEL_TRACES_SAMPLER: always_on
@@ -98,13 +84,6 @@ services:
       - . /eas/emergency-alerts-api/environment.sh && bash /start-api.sh
     environment:
       SERVICE_ACTION: run_periodiq
-
-      AWS_ACCESS_KEY_ID: aws_key
-      AWS_SECRET_ACCESS_KEY: aws_secret
-      AWS_DEFAULT_REGION: us-east-1
-      AWS_ENDPOINT_URL_CLOUDWATCH: http://localstack:4566
-      AWS_ENDPOINT_URL_SQS: http://localstack:4566
-      SQS_QUEUE_BASE_URL: http://sqs.us-east-1.localstack:4566/000000000000
 
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://jaeger:4318/v1/traces
       OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
@@ -164,14 +143,6 @@ services:
     ports:
       - "6017:6017"
     environment:
-      AWS_ACCESS_KEY_ID: aws_key
-      AWS_SECRET_ACCESS_KEY: aws_secret
-      AWS_REGION: us-east-1
-      AWS_ENDPOINT_URL_SQS: http://localstack:4566
-      AWS_ENDPOINT_URL_CLOUDWATCH: http://localstack:4566
-      AWS_ENDPOINT_URL_S3: http://localstack:4566
-      SQS_QUEUE_BASE_URL: http://sqs.us-east-1.localstack:4566/000000000000
-
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://jaeger:4318/v1/traces
       OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
       OTEL_TRACES_SAMPLER: always_on

--- a/compose.yml
+++ b/compose.yml
@@ -61,7 +61,7 @@ services:
       - . /eas/emergency-alerts-api/environment.sh && bash /start-api.sh
     environment:
       SERVICE_ACTION: run_worker
-      WORKER_QUEUE_NAMES: local-periodic-tasks local-broadcast-tasks local-high-priority-tasks
+      WORKER_QUEUE_NAMES: local-dramatiq-periodic-tasks local-dramatiq-broadcast-tasks local-dramatiq-high-priority-tasks
 
       AWS_ACCESS_KEY_ID: aws_key
       AWS_SECRET_ACCESS_KEY: aws_secret

--- a/compose.yml
+++ b/compose.yml
@@ -48,18 +48,20 @@ services:
       - pg
       - localstack
 
-  celery:
+  api-worker:
     build:
       context: repos/emergency-alerts-api
-      dockerfile: Dockerfile.eas-celery
+      dockerfile: Dockerfile.eas-api
       args:
         BASE_IMAGE: localhost/eas-localenv-base
-    image: localhost/eas-localenv-celery
+    image: localhost/eas-localenv-api
     command:
       - bash
       - -c
-      - . /eas/emergency-alerts-api/environment.sh && bash /start-celery.sh
+      - . /eas/emergency-alerts-api/environment.sh && bash /start-api.sh
     environment:
+      SERVICE_ACTION: run_worker
+
       AWS_ACCESS_KEY_ID: aws_key
       AWS_SECRET_ACCESS_KEY: aws_secret
       AWS_DEFAULT_REGION: us-east-1
@@ -70,14 +72,50 @@ services:
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://jaeger:4318/v1/traces
       OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
       OTEL_TRACES_SAMPLER: always_on
-      OTEL_SERVICE_NAME: api
+      OTEL_SERVICE_NAME: api-worker
       OTEL_METRICS_EXPORTER: none
     volumes:
       - ${LOCAL_WORKSPACE_FOLDER:-.}/repos/emergency-alerts-api:/eas/emergency-alerts-api:z
       - ${LOCAL_WORKSPACE_FOLDER:-.}/repos/emergency-alerts-utils:/eas/emergency-alerts-utils:z
 
       - ${LOCAL_WORKSPACE_FOLDER:-.}/environment.sh:/eas/emergency-alerts-api/environment.sh:ro,z
-      - ${LOCAL_WORKSPACE_FOLDER:-.}/repos/emergency-alerts-api/scripts/start-celery.sh:/start-celery.sh:ro,z
+      - ${LOCAL_WORKSPACE_FOLDER:-.}/repos/emergency-alerts-api/scripts/start-api.sh:/start-api.sh:ro,z
+    depends_on:
+      - pg
+      - localstack
+
+  api-periodiq:
+    build:
+      context: repos/emergency-alerts-api
+      dockerfile: Dockerfile.eas-api
+      args:
+        BASE_IMAGE: localhost/eas-localenv-base
+    image: localhost/eas-localenv-api
+    command:
+      - bash
+      - -c
+      - . /eas/emergency-alerts-api/environment.sh && bash /start-api.sh
+    environment:
+      SERVICE_ACTION: run_periodiq
+
+      AWS_ACCESS_KEY_ID: aws_key
+      AWS_SECRET_ACCESS_KEY: aws_secret
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ENDPOINT_URL_CLOUDWATCH: http://localstack:4566
+      AWS_ENDPOINT_URL_SQS: http://localstack:4566
+      SQS_QUEUE_BASE_URL: http://sqs.us-east-1.localstack:4566/000000000000
+
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://jaeger:4318/v1/traces
+      OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
+      OTEL_TRACES_SAMPLER: always_on
+      OTEL_SERVICE_NAME: api-periodiq
+      OTEL_METRICS_EXPORTER: none
+    volumes:
+      - ${LOCAL_WORKSPACE_FOLDER:-.}/repos/emergency-alerts-api:/eas/emergency-alerts-api:z
+      - ${LOCAL_WORKSPACE_FOLDER:-.}/repos/emergency-alerts-utils:/eas/emergency-alerts-utils:z
+
+      - ${LOCAL_WORKSPACE_FOLDER:-.}/environment.sh:/eas/emergency-alerts-api/environment.sh:ro,z
+      - ${LOCAL_WORKSPACE_FOLDER:-.}/repos/emergency-alerts-api/scripts/start-api.sh:/start-api.sh:ro,z
     depends_on:
       - pg
       - localstack

--- a/compose.yml
+++ b/compose.yml
@@ -54,6 +54,7 @@ services:
       - . /eas/emergency-alerts-api/environment.sh && bash /start-api.sh
     environment:
       SERVICE_ACTION: run_worker
+      AWS_ENDPOINT_URL_LAMBDA: http://lambda:5000
       WORKER_QUEUE_NAMES: local-dramatiq-periodic-tasks local-dramatiq-broadcast-tasks local-dramatiq-high-priority-tasks
 
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://jaeger:4318/v1/traces

--- a/compose.yml
+++ b/compose.yml
@@ -241,7 +241,7 @@ services:
       - ${LOCAL_WORKSPACE_FOLDER:-.}/localstack.sh:/etc/localstack/init/ready.d/localstack.sh:ro,z
 
   jaeger:
-    image: cr.jaegertracing.io/jaegertracing/jaeger:2.12.0
+    image: cr.jaegertracing.io/jaegertracing/jaeger:2.15.1
     environment:
       - LOG_LEVEL=debug
     ports:

--- a/compose.yml
+++ b/compose.yml
@@ -61,6 +61,7 @@ services:
       - . /eas/emergency-alerts-api/environment.sh && bash /start-api.sh
     environment:
       SERVICE_ACTION: run_worker
+      WORKER_QUEUE_NAMES: local-periodic-tasks local-broadcast-tasks local-high-priority-tasks
 
       AWS_ACCESS_KEY_ID: aws_key
       AWS_SECRET_ACCESS_KEY: aws_secret

--- a/db-init.sh
+++ b/db-init.sh
@@ -8,6 +8,7 @@ set -e
 . /eas/emergency-alerts-api/environment.sh
 
 psql postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@pg:5432/postgres <<-EOSQL
+    CREATE DATABASE $TEST_DATABASE;
     CREATE DATABASE $DATABASE;
 EOSQL
 

--- a/emergency-alerts-localenv.code-workspace
+++ b/emergency-alerts-localenv.code-workspace
@@ -51,6 +51,7 @@
       "*.html": "jinja"
     },
     "json.format.keepLines": true,
-    "git.autofetch": true
+    "git.autofetch": true,
+    "black-formatter.importStrategy": "fromEnvironment"
   }
 }

--- a/environment.sh
+++ b/environment.sh
@@ -15,6 +15,7 @@ export FLASK_DEBUG=False
 export WERKZEUG_DEBUG_PIN=off
 
 export DATABASE='emergency_alerts'
+export TEST_DATABASE='test_emergency_alerts_master'
 export RDS_HOST='pg'
 export RDS_PORT=5432
 

--- a/environment.sh
+++ b/environment.sh
@@ -4,6 +4,12 @@
 export HOST='hosted'
 export ENVIRONMENT='local'
 
+export AWS_ACCESS_KEY_ID=aws_key
+export AWS_SECRET_ACCESS_KEY=aws_secret
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_ENDPOINT_URL_CLOUDWATCH=http://localstack:4566
+export AWS_ENDPOINT_URL_SQS=http://localstack:4566
+
 export FLASK_APP=application.py
 export FLASK_DEBUG=False
 export WERKZEUG_DEBUG_PIN=off

--- a/environment.sh
+++ b/environment.sh
@@ -9,6 +9,8 @@ export AWS_SECRET_ACCESS_KEY=aws_secret
 export AWS_DEFAULT_REGION=us-east-1
 export AWS_ENDPOINT_URL_CLOUDWATCH=http://localstack:4566
 export AWS_ENDPOINT_URL_SQS=http://localstack:4566
+export AWS_ENDPOINT_URL_S3=http://localstack:4566
+export AWS_ENDPOINT_URL_SSM=http://localstack:4566
 
 export FLASK_APP=application.py
 export FLASK_DEBUG=False

--- a/environment.sh
+++ b/environment.sh
@@ -29,7 +29,8 @@ export ADMIN_EXTERNAL_URL=http://localhost:6012
 export ADMIN_ACTION_ALLOW_SELF_APPROVAL=true
 export GOVUK_ALERTS_S3_BUCKET_NAME='local-govuk-alerts'
 export GOVUK_ALERTS_HOST_URL=http://localhost:6017
-export NOTIFY_API_CLIENT_SECRET=
+export GOVUK_CLIENT_SECRET=
+export GOVUK_ALERTS_PUBLISH_CLIENT_SECRET=
 export FASTLY_ENABLED=false
 # If running the functional tests on a host - this is the IP of the host from the container's PoV
 # (at least from the perspective of Docker Desktop on macOS)

--- a/lambda-api.py
+++ b/lambda-api.py
@@ -1,4 +1,5 @@
 import json
+from time import sleep
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 
@@ -17,6 +18,8 @@ class LambdaHandler(BaseHTTPRequestHandler):
                 },
             }
             response_data = json.dumps(response_payload).encode("utf-8")
+
+            sleep(2)
 
             self.send_response(200)
             self.send_header("Content-Type", "application/json")

--- a/localstack.sh
+++ b/localstack.sh
@@ -5,6 +5,7 @@ set -e
 awslocal sqs create-queue --queue-name local-periodic-tasks --attributes VisibilityTimeout=300
 awslocal sqs create-queue --queue-name local-govuk-alerts --attributes VisibilityTimeout=300
 awslocal sqs create-queue --queue-name local-broadcast-tasks --attributes VisibilityTimeout=300
+awslocal sqs create-queue --queue-name local-high-priority-tasks --attributes VisibilityTimeout=300
 
 # Create S3 bucket
 awslocal s3 mb s3://local-govuk-alerts

--- a/localstack.sh
+++ b/localstack.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-set -e
+set -ex
 
 # Create SQS queues
-awslocal sqs create-queue --queue-name local-periodic-tasks --attributes VisibilityTimeout=300
-awslocal sqs create-queue --queue-name local-govuk-alerts --attributes VisibilityTimeout=300
-awslocal sqs create-queue --queue-name local-broadcast-tasks --attributes VisibilityTimeout=300
-awslocal sqs create-queue --queue-name local-high-priority-tasks --attributes VisibilityTimeout=300
+DLQ_URL=$(awslocal sqs create-queue --queue-name local-dramatiq-dlq --attributes VisibilityTimeout=300 --query 'QueueUrl' --output text)
+DLQ_ARN=$(awslocal sqs get-queue-attributes --queue-url "$DLQ_URL" --attribute-names QueueArn --query 'Attributes.QueueArn' --output text)
+
+awslocal sqs create-queue --queue-name local-dramatiq-periodic-tasks --attributes "VisibilityTimeout=300,RedrivePolicy='{\"deadLetterTargetArn\":\"$DLQ_ARN\",\"maxReceiveCount\":\"3\"}'"
+awslocal sqs create-queue --queue-name local-dramatiq-govuk-alerts --attributes "VisibilityTimeout=300,RedrivePolicy='{\"deadLetterTargetArn\":\"$DLQ_ARN\",\"maxReceiveCount\":\"3\"}'"
+awslocal sqs create-queue --queue-name local-dramatiq-broadcast-tasks --attributes "VisibilityTimeout=300,RedrivePolicy='{\"deadLetterTargetArn\":\"$DLQ_ARN\",\"maxReceiveCount\":\"3\"}'"
+awslocal sqs create-queue --queue-name local-dramatiq-high-priority-tasks --attributes "VisibilityTimeout=300,RedrivePolicy='{\"deadLetterTargetArn\":\"$DLQ_ARN\",\"maxReceiveCount\":\"3\"}'"
 
 # Create S3 bucket
 awslocal s3 mb s3://local-govuk-alerts


### PR DESCRIPTION
See https://github.com/alphagov/emergency-alerts-api/pull/320 (and https://github.com/alphagov/emergency-alerts-infra/pull/1605) for context.