### PR TITLE
Localenv: Fix adding GOVUK_CLIENT_SECRET and co

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // Note: This has *not* been extensively tested.
 {
 	"name": "Python 3",
-	"image": "mcr.microsoft.com/devcontainers/python:2-3.12-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": { },
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": { }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository expects a specific folder layout. More specifically, repositorie
 
 ```bash
 git clone https://github.com/alphagov/emergency-alerts-localenv
+mkdir -p emergency-alerts-localenv/repos
 cd emergency-alerts-localenv/repos
 git clone https://github.com/alphagov/emergency-alerts-api.git
 git clone https://github.com/alphagov/emergency-alerts-govuk.git
@@ -43,21 +44,21 @@ Running on Linux? Make sure the repos have rw for everyone - as the containers r
 > make generate-version-file && npm ci && npm run build && cp app/broadcast_areas/broadcast-areas-test.sqlite3 app/broadcast_areas/broadcast-areas.sqlite3
 > ```
 
-For development you'll want to create a Python virtual environment in each repo and install Python dependencies (and build Node components too)
+For proper development you'll want to create a Python virtual environment in each repo and install Python dependencies (and build Node components too)
 ```bash
 # in repos/
 cd emergency-alerts-govuk
 python -m venv venv
-make bootstrap
+source venv/bin/activate; make bootstrap; deactivate
 cd ../emergency-alerts-api
 python -m venv venv
-make bootstrap
+source venv/bin/activate; make bootstrap; deactivate
 cd ../emergency-alerts-admin
 python -m venv venv
-make bootstrap
+source venv/bin/activate; make bootstrap; deactivate
 cd ../emergency-alerts-utils
 python -m venv venv
-make bootstrap
+source venv/bin/activate; make bootstrap; deactivate
 ```
 
 Admin requires a large SQLite Database of location libraries. You can fetch this from the `infra-mgt` AWS account in an S3 bucket.
@@ -82,9 +83,11 @@ In general you can largely make these values up, but you'll only want to set the
 Now you should be able to ask Docker Compose to come up. We use a shared based image which there isn't great native support for.
 You may also need to ensure Postgres and Localstack are up and running before the others - Celery nopes out immediately if SQS isn't populated.
 ```
-. ./environment.sh
-docker compose up -d utils localstack pg jaeger lambda
+source environment.sh
+docker compose up -d --build utils localstack pg jaeger lambda
 docker compose build api
+docker compose up -d api db-init
+# You might want to wait for API to be up
 docker compose up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,14 @@ It will need copying to `emergency-alerts-localenv/repos/emergency-alerts-admin/
 Modify the `emergency-alerts-localenv/environment.sh` file by adding the credentials for the environment variables:
  - MASTER_USERNAME
  - MASTER_PASSWORD
+ - NOTIFY_API_CLIENT_SECRET
  - SECRET_KEY
  - DANGEROUS_SALT
  - ENCRYPTION_DANGEROUS_SALT
  - ENCRYPTION_SECRET_KEY
  - ADMIN_CLIENT_SECRET
+ - GOVUK_CLIENT_SECRET
+ - GOVUK_ALERTS_PUBLISH_CLIENT_SECRET
  - POSTGRES_PASSWORD
  - POSTGRES_USER
 

--- a/environment.sh
+++ b/environment.sh
@@ -13,27 +13,33 @@ export RDS_HOST='pg'
 export RDS_PORT=5432
 
 export USE_RDS_IAM_AUTH="false"
-# Confusingly master here refers to the application's DB user (i.e. not the DB superuser)
-export MASTER_USERNAME=
-export MASTER_PASSWORD=
 
 export API_HOST_NAME=http://api:6011
 export ADMIN_EXTERNAL_URL=http://localhost:6012
 export ADMIN_ACTION_ALLOW_SELF_APPROVAL=true
 export GOVUK_ALERTS_S3_BUCKET_NAME='local-govuk-alerts'
 export GOVUK_ALERTS_HOST_URL=http://localhost:6017
-export NOTIFY_API_CLIENT_SECRET=
 export FASTLY_ENABLED=false
 # If running the functional tests on a host - this is the IP of the host from the container's PoV
 # (at least from the perspective of Docker Desktop on macOS)
 export FUNCTIONAL_TEST_IPS='172.18.0.1'
 export FUNCTIONAL_TEST_USER_ID='44153bb8-db31-4cb0-8cee-b909a5482d1a'
 
+# ----
+
+# Confusingly master here refers to the application's DB user (i.e. not the DB superuser)
+# Make sure this username is different to POSTGRES_USER below
+export MASTER_USERNAME=
+export MASTER_PASSWORD=
+
+export NOTIFY_API_CLIENT_SECRET=
 export SECRET_KEY=
 export DANGEROUS_SALT=
 export ENCRYPTION_DANGEROUS_SALT=
 export ENCRYPTION_SECRET_KEY=
 export ADMIN_CLIENT_SECRET=
+export GOVUK_CLIENT_SECRET=
+export GOVUK_ALERTS_PUBLISH_CLIENT_SECRET=
 
 # The superuser within Postgres
 export POSTGRES_USER=

--- a/localstack.sh
+++ b/localstack.sh
@@ -5,6 +5,7 @@ set -e
 awslocal sqs create-queue --queue-name local-periodic-tasks --attributes VisibilityTimeout=300
 awslocal sqs create-queue --queue-name local-govuk-alerts --attributes VisibilityTimeout=300
 awslocal sqs create-queue --queue-name local-broadcast-tasks --attributes VisibilityTimeout=300
+awslocal sqs create-queue --queue-name local-high-priority-tasks --attributes VisibilityTimeout=300
 
 # Create S3 bucket
 awslocal s3 mb s3://local-govuk-alerts


### PR DESCRIPTION
Localenv hasn't had an update in a while and the config we need has evolved somewhat with GovUK no longer having a hardcoded secret (or a fallback), and the recent publish status bits. This is incorporated in my Dramatiq localenv but we might as well roll it here. Also it seems I didn't separate dependencies per-project correctly but all my testing was in a devcontainer on a Linux machine.

In addition it seemed the high-priority queue wasn't made via config. I think Celery at one point just made it on the fly so I never noticed?

I'll be honest - I wish we could just put random nonsense into `environment.sh` here and commit them. It's what I do locally anyway, it's just there to tie the services together.