### PR TITLE
EAS-2957: localstack setup for blue/green publishing

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -32,6 +32,8 @@ export GOVUK_ALERTS_BLUE_S3_BUCKET_NAME='local-govuk-alerts-blue'
 export GOVUK_ALERTS_GREEN_S3_BUCKET_NAME='local-govuk-alerts-green'
 export GOVUK_ALERTS_ARCHIVE_S3_BUCKET_NAME='local-govuk-alerts-archive'
 export GOVUK_ALERTS_CURRENT_BUCKET_PARAM='govuk-website-current'
+# Cloudfront endpoint not available in free localstack, so disable
+export GOVUK_ALERTS_CLOUDFRONT_ENABLED=false
 export GOVUK_ALERTS_HOST_URL=http://localhost:6017
 export FASTLY_ENABLED=false
 # If running the functional tests on a host - this is the IP of the host from the container's PoV


### PR DESCRIPTION
Add GOVUK_ALERTS_CLOUDFRONT_ENABLED which should be set to false in localstack environments.