### PR TITLE
Log the resolution of the tooling repo in PR script

### DIFF
--- a/run-for-functional-tests.sh
+++ b/run-for-functional-tests.sh
@@ -34,6 +34,7 @@ echo "API: $(cd emergency-alerts-api; git show -s --pretty='format:%H - %s')"
 echo "GovUK: $(cd emergency-alerts-govuk; git show -s --pretty='format:%H - %s')"
 echo "Admin: $(cd emergency-alerts-admin; git show -s --pretty='format:%H - %s')"
 echo "Utils: $(cd emergency-alerts-utils; git show -s --pretty='format:%H - %s')"
+echo "Tooling: $(cd emergency-alerts-tooling; git show -s --pretty='format:%H - %s')"
 
 echo "##[endgroup]"
 echo "##[group]Prep services (generate version and compile JS/CSS)"


### PR DESCRIPTION
A minor oversight, should allow us to see what version of tooling was used in the logs.